### PR TITLE
Book.from_stream and Book#load_stream methods to load CSV streams

### DIFF
--- a/lib/workbook/book.rb
+++ b/lib/workbook/book.rb
@@ -151,23 +151,26 @@ module Workbook
       return wb
     end
 
-    # Create an instance from the given stream or string, which should be in CSV format
+    # Create an instance from the given stream or string, which should be in CSV or TXT format
     #
-    # @param [StringIO] a StringIO stream or String object, with data in CSV format
+    # @param [StringIO] a StringIO stream or String object, with data in CSV or TXT format
+    # @param [Symbol] :csv or :txt, indicating the format of the first parameter
     # @return [Workbook::Book] A new instance
-    def self.from_stream(stringio_or_string)
+    def self.read(stringio_or_string, filetype)
       wb = self.new
-      wb.load_stream(stringio_or_string)
+      wb.read(stringio_or_string, filetype)
       wb
     end
     
     # Load the CSV data contained in the given StringIO or String object
     #
     # @param [StringIO] a StringIO stream or String object, with data in CSV format
-    def load_stream(stringio_or_string)
+    # @param [Symbol] :csv or :txt, indicating the format of the first parameter
+    def read(stringio_or_string, filetype)
+      raise ArgumentError.new("The filetype parameter should be either :csv or :txt") unless [:csv, :txt].include?(filetype)
       t = stringio_or_string.respond_to?(:read) ? stringio_or_string.read : stringio_or_string.to_s
       t = text_to_utf8(t)
-      load_csv(t)
+      send(:"parse_#{filetype}", t)
     end
 
     # Create or open the existing sheet at an index value

--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -61,4 +61,10 @@ class TestWorkbook < Test::Unit::TestCase
     t = w.text_to_utf8(t)
     assert_equal("a\tb\tc\td", t.split(/(\n|\r)/).first)
   end
+  
+  def test_read_bad_filetype
+    assert_raises(ArgumentError) { Workbook::Book.read("test string here", :xls) }
+    assert_raises(ArgumentError) { Workbook::Book.read("test string here", :ods) }
+    assert_raises(ArgumentError) { Workbook::Book.read("test string here", :xlsx) }
+  end
 end

--- a/test/test_readers_csv_reader.rb
+++ b/test/test_readers_csv_reader.rb
@@ -51,9 +51,9 @@ module Readers
       assert_equal(42000,w.sheet.table[3][:b].value)
       assert_equal(nil,w.sheet.table[2][:c].value)
     end
-    def test_from_stream
+    def test_class_read_string
       s = File.read 'test/artifacts/simple_csv.csv'
-      w = Workbook::Book.from_stream( s )
+      w = Workbook::Book.read( s, :csv )
       # reads
       #       a,b,c,d
       #       1,2,3,4
@@ -65,10 +65,25 @@ module Readers
       assert_equal("asdf",w.sheet.table[3][:a].value)
       assert_equal(Date.new(2001,2,2),w.sheet.table[3][:d].value)
     end
-    def test_load_stream
+    def test_instance_read_string
       w = Workbook::Book.new
       s = File.read 'test/artifacts/simple_csv.csv'
-      w.load_stream( s )
+      w.read( s, :csv )
+      # reads
+      #       a,b,c,d
+      #       1,2,3,4
+      #       5,3,2,1
+      #       "asdf",123,12,2001-02-02
+      #       
+      assert_equal([:a,:b,:c,:d],w.sheet.table.header.to_symbols)
+      assert_equal(3,w.sheet.table[2][:b].value)
+      assert_equal("asdf",w.sheet.table[3][:a].value)
+      assert_equal(Date.new(2001,2,2),w.sheet.table[3][:d].value)
+    end
+    def test_instance_read_stringio
+      w = Workbook::Book.new
+      sio = StringIO.new(File.read 'test/artifacts/simple_csv.csv')
+      w.read( sio, :csv )
       # reads
       #       a,b,c,d
       #       1,2,3,4

--- a/test/test_readers_txt_reader.rb
+++ b/test/test_readers_txt_reader.rb
@@ -26,5 +26,58 @@ module Readers
       assert_equal(nil,w.sheet.table[2][:c].value)
     end
     
+    def test_excel_class_read_string
+      s = File.read("test/artifacts/excel_different_types.txt")
+      w = Workbook::Book.read(s, :txt)
+      # reads
+      #   a,b,c,d
+      # 2012-02-22,2014-12-27,2012-11-23,2012-11-12T04:20:00+00:00
+      # c,222.0,,0027-12-14T05:21:00+00:00
+      # 2012-01-22T11:00:00+00:00,42000.0,"goh, idd",ls
+      
+      assert_equal([:a,:b,:c, :d],w.sheet.table.header.to_symbols)
+      assert_equal(Date.new(2012,2,22),w.sheet.table[1][:a].value)
+      assert_equal("c",w.sheet.table[2][:a].value)
+      assert_equal(DateTime.new(2012,1,22,11),w.sheet.table[3][:a].value)
+      assert_equal(42000,w.sheet.table[3][:b].value)
+      assert_equal(nil,w.sheet.table[2][:c].value)
+    end
+    
+    def test_excel_instance_read_string
+      s = File.read("test/artifacts/excel_different_types.txt")
+      w = Workbook::Book.new
+      w.read(s, :txt)
+      # reads
+      #   a,b,c,d
+      # 2012-02-22,2014-12-27,2012-11-23,2012-11-12T04:20:00+00:00
+      # c,222.0,,0027-12-14T05:21:00+00:00
+      # 2012-01-22T11:00:00+00:00,42000.0,"goh, idd",ls
+      
+      assert_equal([:a,:b,:c, :d],w.sheet.table.header.to_symbols)
+      assert_equal(Date.new(2012,2,22),w.sheet.table[1][:a].value)
+      assert_equal("c",w.sheet.table[2][:a].value)
+      assert_equal(DateTime.new(2012,1,22,11),w.sheet.table[3][:a].value)
+      assert_equal(42000,w.sheet.table[3][:b].value)
+      assert_equal(nil,w.sheet.table[2][:c].value)
+    end
+    
+    def test_excel_instance_read_stringio
+      sio = StringIO.new(File.read("test/artifacts/excel_different_types.txt"))
+      w = Workbook::Book.new
+      w.read(sio, :txt)
+      # reads
+      #   a,b,c,d
+      # 2012-02-22,2014-12-27,2012-11-23,2012-11-12T04:20:00+00:00
+      # c,222.0,,0027-12-14T05:21:00+00:00
+      # 2012-01-22T11:00:00+00:00,42000.0,"goh, idd",ls
+      
+      assert_equal([:a,:b,:c, :d],w.sheet.table.header.to_symbols)
+      assert_equal(Date.new(2012,2,22),w.sheet.table[1][:a].value)
+      assert_equal("c",w.sheet.table[2][:a].value)
+      assert_equal(DateTime.new(2012,1,22,11),w.sheet.table[3][:a].value)
+      assert_equal(42000,w.sheet.table[3][:b].value)
+      assert_equal(nil,w.sheet.table[2][:c].value)
+    end
+    
   end
 end


### PR DESCRIPTION
Gives the ability to load CSV StringIO and String objects instead of files.

(It would be great to have this capability for xls and xlsx files, but it appears that RubyXL requires a file. Perhaps for xlsx files this is unrealistic as they are zip files and would have to be uncompressed somewhere.)
