### PR TITLE
pass open file to Roo::Excelx so it works when filename has no extension or wrong extension

### DIFF
--- a/lib/workbook/readers/xlsx_reader.rb
+++ b/lib/workbook/readers/xlsx_reader.rb
@@ -15,7 +15,6 @@ module Workbook
         self.load_xlsx file_obj, options
       end
       def load_xlsx file_obj, options={}
-        file_obj = file_obj.path if file_obj.is_a? File
         # file_obj = file_obj.match(/^\/(.*)/) ? file_obj : "./#{file_obj}"
         # p "opening #{file_obj}"
         sp = Roo::Excelx.new(file_obj)


### PR DESCRIPTION
I'm trying to open an uploaded file, so name is kind of RackMultipart20160418-5180-seqzi, I know it's xlsx because I get extension from uploaded_file.original_filename, and Roo::Excelx.new(File.open(uploaded_file.path, 'rb')) works, but Workbook::Book.open(uploaded_file.path, 'xlsx') fails because it passes temp path to Roo::Excelx